### PR TITLE
Ensure mtime change detection in caching test

### DIFF
--- a/tests/test_file_io_optimization.py
+++ b/tests/test_file_io_optimization.py
@@ -125,9 +125,10 @@ class TestFileIOOptimization:
 - [ ] Write integration tests
 """
         plan_file.write_text(modified_content, encoding='utf-8')
-        
-        # Add a small delay to ensure mtime difference is detectable
-        time.sleep(0.01)
+
+        # Explicitly update the mtime so the change is detected on all platforms
+        forced_mtime = os.path.getmtime(plan_file) + 1
+        os.utime(plan_file, (forced_mtime, forced_mtime))
         
         with patch('builtins.open', side_effect=mock_file_open):
             # Reset file read counter for this part of the test


### PR DESCRIPTION
## Summary
- Replace unreliable sleep in `test_file_io_optimization` with explicit `os.utime` call to guarantee modification time change.

## Testing
- `pytest tests/test_file_io_optimization.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0a1cdf30883229a5897772756cf1b