### PR TITLE
Use underscore in Implementation Plan filename

### DIFF
--- a/config.py
+++ b/config.py
@@ -23,7 +23,7 @@ import json
 # FILE PATHS
 # =============================================================================
 # Core project files and directories
-IMPLEMENTATION_PLAN_FILE = "Implementation Plan.md"
+IMPLEMENTATION_PLAN_FILE = "Implementation_Plan.md"
 PRD_FILE = "PRD.md"
 CLAUDE_FILE = "CLAUDE.md"
 SIGNAL_FILE = ".claude/signal_task_complete"

--- a/task_tracker.py
+++ b/task_tracker.py
@@ -41,9 +41,9 @@ def check_file_exists(filepath: str) -> bool:
 
 
 class TaskTracker:
-    """Tracks task completion status from Implementation Plan.md file.
+    """Tracks task completion status from Implementation_Plan.md file.
     
-    This class manages task state by reading from Implementation Plan.md and
+    This class manages task state by reading from Implementation_Plan.md and
     provides failure tracking functionality to limit retry attempts on failing tasks.
     
     Attributes:
@@ -73,7 +73,7 @@ class TaskTracker:
         self._cache_misses: int = 0
     
     def _load_file_content(self) -> str:
-        """Load Implementation Plan file content with caching.
+        """Load Implementation_Plan file content with caching.
         
         This method handles file caching to minimize I/O operations. The cache
         is invalidated when the file modification time changes.
@@ -141,9 +141,9 @@ class TaskTracker:
         self._cached_mtime = None
     
     def get_next_task(self) -> Tuple[Optional[str], bool]:
-        """Get the next incomplete task from Implementation Plan.md.
+        """Get the next incomplete task from Implementation_Plan.md.
         
-        Reads the Implementation Plan.md file and finds the first task marked
+        Reads the Implementation_Plan.md file and finds the first task marked
         as incomplete (with '- [ ]' marker). This implements sequential task
         processing where tasks must be completed in order.
         
@@ -161,7 +161,7 @@ class TaskTracker:
         """
         logger = LOGGERS['task_tracker']
         
-        # Check if Implementation Plan.md exists
+        # Check if Implementation_Plan.md exists
         if not check_file_exists(IMPLEMENTATION_PLAN_FILE):
             logger.warning(f"Implementation Plan file not found: {IMPLEMENTATION_PLAN_FILE}")
             return (None, True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,7 +42,7 @@ class TestConfigModule:
         
         # Test file path constants exist and have correct values
         expected_file_paths = {
-            'IMPLEMENTATION_PLAN_FILE': "Implementation Plan.md",
+            'IMPLEMENTATION_PLAN_FILE': "Implementation_Plan.md",
             'PRD_FILE': "PRD.md", 
             'CLAUDE_FILE': "CLAUDE.md",
             'SIGNAL_FILE': ".claude/signal_task_complete",

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -84,7 +84,7 @@ def setup_temp_environment(tmp_path):
     logs_dir.mkdir()
     
     # Create required files
-    implementation_plan = tmp_path / "Implementation Plan.md"
+    implementation_plan = tmp_path / "Implementation_Plan.md"
     prd_file = tmp_path / "PRD.md"
     claude_file = tmp_path / "CLAUDE.md"
     
@@ -176,8 +176,8 @@ def test_environment(tmp_path, monkeypatch):
     logs_dir = claude_dir / "logs"
     logs_dir.mkdir()
     
-    # Create Implementation Plan.md with default content
-    implementation_plan = tmp_path / "Implementation Plan.md"
+    # Create Implementation_Plan.md with default content
+    implementation_plan = tmp_path / "Implementation_Plan.md"
     default_plan_content = "# Implementation Plan\n\n- [X] Default completed task"
     implementation_plan.write_text(default_plan_content, encoding="utf-8")
     
@@ -225,7 +225,7 @@ def main_loop_test_setup(test_environment):
     """
     env = test_environment
     
-    # Create Implementation Plan.md with multiple tasks for testing progression
+    # Create Implementation_Plan.md with multiple tasks for testing progression
     implementation_plan_content = """# Implementation Plan
 
 ## Phase 1: Development
@@ -246,10 +246,10 @@ def create_main_loop_command_mock(implementation_plan_path):
     Helper function to create a mock command handler for main loop tests.
     
     This mock simulates the /update command progressively marking tasks complete
-    by rewriting the Implementation Plan.md file.
+    by rewriting the Implementation_Plan.md file.
     
     Args:
-        implementation_plan_path: Path to the Implementation Plan.md file to modify
+        implementation_plan_path: Path to the Implementation_Plan.md file to modify
         
     Returns:
         Mock function that can be used as side_effect for run_claude_command
@@ -335,7 +335,7 @@ def refactoring_loop_test_setup(test_environment):
     """
     env = test_environment
     
-    # Create Implementation Plan.md with all tasks complete
+    # Create Implementation_Plan.md with all tasks complete
     implementation_plan_content = """# Implementation Plan
 
 ## Phase 1: Development

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -64,16 +64,16 @@ class TestOrchestratorPrerequisiteFileChecks:
     
     def test_orchestrator_exits_gracefully_when_implementation_plan_missing(self, tmp_path, monkeypatch):
         """
-        Test that the orchestrator exits gracefully with an error if Implementation Plan.md is missing.
+        Test that the orchestrator exits gracefully with an error if Implementation_Plan.md is missing.
         
-        This test creates a temporary directory without the Implementation Plan.md file,
+        This test creates a temporary directory without the Implementation_Plan.md file,
         changes to that directory, and verifies that the orchestrator exits with the
         appropriate error code and message.
         
         This test will initially fail because main() doesn't implement these checks yet.
         This is the RED phase of TDD - the test must fail first.
         """
-        # Change to temporary directory where Implementation Plan.md doesn't exist
+        # Change to temporary directory where Implementation_Plan.md doesn't exist
         monkeypatch.chdir(tmp_path)
         
         # Create .claude directory to avoid ensure_settings_file issues
@@ -91,7 +91,7 @@ class TestOrchestratorPrerequisiteFileChecks:
             
             # Mock print to capture error messages
             with patch('builtins.print') as mock_print:
-                # Call main function - it should detect missing Implementation Plan.md and exit
+                # Call main function - it should detect missing Implementation_Plan.md and exit
                 import pytest
                 with pytest.raises(SystemExit):
                     main()
@@ -103,16 +103,16 @@ class TestOrchestratorPrerequisiteFileChecks:
                 mock_print.assert_called()
                 printed_messages = [str(call.args[0]) for call in mock_print.call_args_list]
                 error_message_found = any(
-                    "Implementation Plan.md" in msg or "implementation plan" in msg.lower()
+                    "Implementation_Plan.md" in msg or "implementation plan" in msg.lower()
                     for msg in printed_messages
                 )
-                assert error_message_found, f"Expected error message about missing Implementation Plan.md, got: {printed_messages}"
+                assert error_message_found, f"Expected error message about missing Implementation_Plan.md, got: {printed_messages}"
     
     def test_orchestrator_prints_warning_when_prd_md_missing(self, mock_claude_command, mock_get_latest_status, test_environment):
         """
         Test that the orchestrator prints a warning if PRD.md is missing.
         
-        This test creates a temporary directory with Implementation Plan.md present
+        This test creates a temporary directory with Implementation_Plan.md present
         but PRD.md missing, and verifies that a warning is printed.
         
         This test will initially fail because main() doesn't implement these checks yet.
@@ -147,7 +147,7 @@ class TestOrchestratorPrerequisiteFileChecks:
         """
         Test that the orchestrator prints a warning if CLAUDE.md is missing.
         
-        This test creates a temporary directory with Implementation Plan.md present
+        This test creates a temporary directory with Implementation_Plan.md present
         but CLAUDE.md missing, and verifies that a warning is printed.
         
         This test will initially fail because main() doesn't implement these checks yet.
@@ -220,7 +220,7 @@ class TestTaskTracker:
         """
         Test that TaskTracker.get_next_task correctly identifies the first incomplete task.
         
-        Given an Implementation Plan.md file with multiple tasks where some are complete
+        Given an Implementation_Plan.md file with multiple tasks where some are complete
         and some are incomplete, the get_next_task method should return the first task
         marked with [ ] (incomplete).
         
@@ -230,8 +230,8 @@ class TestTaskTracker:
         # Change to temporary directory
         monkeypatch.chdir(tmp_path)
         
-        # Create Implementation Plan.md with mixed complete/incomplete tasks
-        implementation_plan = tmp_path / "Implementation Plan.md"
+        # Create Implementation_Plan.md with mixed complete/incomplete tasks
+        implementation_plan = tmp_path / "Implementation_Plan.md"
         implementation_plan_content = """# Implementation Plan
 
 ## Phase 1: Setup
@@ -275,7 +275,7 @@ class TestTaskTracker:
         """
         Test that TaskTracker.get_next_task returns (None, True) when all tasks are complete.
         
-        Given an Implementation Plan.md file where all tasks are marked with [X] (complete),
+        Given an Implementation_Plan.md file where all tasks are marked with [X] (complete),
         the get_next_task method should return (None, True) indicating no more work to do.
         
         This test will initially fail because the TaskTracker class doesn't exist yet.
@@ -284,8 +284,8 @@ class TestTaskTracker:
         # Change to temporary directory
         monkeypatch.chdir(tmp_path)
         
-        # Create Implementation Plan.md with all tasks complete
-        implementation_plan = tmp_path / "Implementation Plan.md"
+        # Create Implementation_Plan.md with all tasks complete
+        implementation_plan = tmp_path / "Implementation_Plan.md"
         implementation_plan_content = """# Implementation Plan
 
 ## Phase 1: Setup
@@ -324,19 +324,19 @@ class TestTaskTracker:
     
     def test_get_next_task_returns_none_true_when_implementation_plan_missing(self, tmp_path, monkeypatch):
         """
-        Test that TaskTracker.get_next_task returns (None, True) when Implementation Plan.md doesn't exist.
+        Test that TaskTracker.get_next_task returns (None, True) when Implementation_Plan.md doesn't exist.
         
-        Given a directory where Implementation Plan.md file does not exist,
+        Given a directory where Implementation_Plan.md file does not exist,
         the get_next_task method should return (None, True) indicating no work can be done.
         
         This test will initially fail because the TaskTracker class doesn't exist yet.
         This is the RED phase of TDD - the test must fail first.
         """
-        # Change to temporary directory where Implementation Plan.md doesn't exist
+        # Change to temporary directory where Implementation_Plan.md doesn't exist
         monkeypatch.chdir(tmp_path)
         
-        # Ensure Implementation Plan.md does NOT exist
-        implementation_plan = tmp_path / "Implementation Plan.md"
+        # Ensure Implementation_Plan.md does NOT exist
+        implementation_plan = tmp_path / "Implementation_Plan.md"
         if implementation_plan.exists():
             implementation_plan.unlink()
         
@@ -356,8 +356,8 @@ class TestTaskTracker:
         task, all_complete = result
         
         # Verify that all_complete is True and task is None when file doesn't exist
-        assert all_complete is True, "all_complete should be True when Implementation Plan.md doesn't exist"
-        assert task is None, f"task should be None when Implementation Plan.md doesn't exist, got: {task}"
+        assert all_complete is True, "all_complete should be True when Implementation_Plan.md doesn't exist"
+        assert task is None, f"task should be None when Implementation_Plan.md doesn't exist, got: {task}"
 
 
 class TestTaskTrackerFailureTracking:
@@ -1010,7 +1010,7 @@ class TestMainOrchestrationLoop:
         Test that the main orchestration loop executes the correct TDD sequence in the happy path.
         
         This test verifies the happy path scenario where:
-        1. A task is available in Implementation Plan.md
+        1. A task is available in Implementation_Plan.md
         2. The main loop executes /clear, /continue, /validate, /update in sequence
         3. After /validate, get_latest_status returns "validation_passed"
         4. After /update, get_latest_status returns "project_incomplete" 
@@ -1158,7 +1158,7 @@ class TestRefactoringLoop:
         Test that the refactoring loop executes the complete sequence when project_complete status is returned.
         
         This test verifies the refactoring loop scenario where:
-        1. All tasks in Implementation Plan.md are complete (return project_complete after /update)
+        1. All tasks in Implementation_Plan.md are complete (return project_complete after /update)
         2. The main loop enters refactoring mode and calls /checkin
         3. Based on checkin status, it calls /refactor if refactoring is needed
         4. If refactoring tasks are found, it calls /finalize to implement them
@@ -1259,8 +1259,8 @@ class TestRefactoringLoop:
         # Change to temporary directory
         monkeypatch.chdir(tmp_path)
         
-        # Create Implementation Plan.md with all tasks complete
-        implementation_plan = tmp_path / "Implementation Plan.md"
+        # Create Implementation_Plan.md with all tasks complete
+        implementation_plan = tmp_path / "Implementation_Plan.md"
         implementation_plan_content = """# Implementation Plan
 
 ## Phase 1: Development
@@ -1350,8 +1350,8 @@ class TestRefactoringLoop:
         # Change to temporary directory
         monkeypatch.chdir(tmp_path)
         
-        # Create Implementation Plan.md with one incomplete task
-        implementation_plan = tmp_path / "Implementation Plan.md"
+        # Create Implementation_Plan.md with one incomplete task
+        implementation_plan = tmp_path / "Implementation_Plan.md"
         implementation_plan_content = """# Implementation Plan
 
 ## Phase 1: Development
@@ -2158,8 +2158,8 @@ class TestLogging:
         # Change to temporary directory
         monkeypatch.chdir(tmp_path)
         
-        # Create Implementation Plan.md with all tasks complete to ensure quick execution
-        implementation_plan = tmp_path / "Implementation Plan.md"
+        # Create Implementation_Plan.md with all tasks complete to ensure quick execution
+        implementation_plan = tmp_path / "Implementation_Plan.md"
         implementation_plan_content = """# Implementation Plan
 
 ## Phase 1: Setup


### PR DESCRIPTION
## Summary
- Standardize `IMPLEMENTATION_PLAN_FILE` to `Implementation_Plan.md`.
- Update task tracker and tests to reference `Implementation_Plan.md`.

## Testing
- `pytest -q` *(fails: Error message format is inconsistent in command_executor)*


------
https://chatgpt.com/codex/tasks/task_e_68a0a4feebe08322b438b461e47b22cf